### PR TITLE
URI Parameters are only populated with the last URI Parameter

### DIFF
--- a/src/main/java/org/raml/parser/visitor/RamlDocumentBuilder.java
+++ b/src/main/java/org/raml/parser/visitor/RamlDocumentBuilder.java
@@ -149,7 +149,7 @@ public class RamlDocumentBuilder extends YamlDocumentBuilder<Raml>
     private void populateDefaultUriParameters(Resource resource)
     {
         Pattern pattern = Pattern.compile(URI_PATTERN);
-        Matcher matcher = pattern.matcher(resource.getRelativeUri());
+        Matcher matcher = pattern.matcher(resource.getParentUri() + resource.getRelativeUri());
         while (matcher.find())
         {
             String paramName = matcher.group(1);


### PR DESCRIPTION
I've been using the raml-jaxrs-codegen project and found an issue with the PathParam generation.

Let's say my RAML file has the following URIs:

```
/posts:
  /{postId}:
    /{commentId}:
```

In the generated interface, the method corresponding to the {commendId} will ONLY contain a single PathParam, but I expect 2 PathParams (one for postId, one for commentId).

This issue stems from a class in the raml-java-parser project -- to be specific, the class "org.raml.parser.visitor.RamlDocumentBuilder" and the function "populateDefaultUriParameters"
In this function, URI Parameters are only created for the last URI parameter, instead of all the URI parameters.
