### PR TITLE
The dash character (-) should be part of valid URIs.

### DIFF
--- a/src/main/java/org/raml/parser/rule/BaseUriRule.java
+++ b/src/main/java/org/raml/parser/rule/BaseUriRule.java
@@ -32,7 +32,7 @@ public class BaseUriRule extends SimpleRule
     public static final String URI_NOT_VALID_MESSAGE = "The baseUri element is not a valid URI";
     public static final String VERSION_NOT_PRESENT_MESSAGE = "version parameter must exist in the API definition";
 
-    public static final String URI_PATTERN = "[.*]?\\{([a-zA-Z0-9_-]+)?\\}[.*]*";
+    public static final String URI_PATTERN = "[.*]?\\{(\\w+)?\\}[.*]*";
     private String baseUri;
     private Set<String> parameters;
     private Pattern pattern;

--- a/src/main/java/org/raml/parser/visitor/RamlDocumentBuilder.java
+++ b/src/main/java/org/raml/parser/visitor/RamlDocumentBuilder.java
@@ -148,7 +148,7 @@ public class RamlDocumentBuilder extends YamlDocumentBuilder<Raml>
 
     private void populateDefaultUriParameters(Resource resource)
     {
-        Pattern pattern = Pattern.compile(URI_PATTERN);
+        Pattern pattern = Pattern.compile("[.*]?\\{([a-zA-Z0-9_-]+)?\\}[.*]*");
         Matcher matcher = pattern.matcher(resource.getRelativeUri());
         while (matcher.find())
         {


### PR DESCRIPTION
I've been using the raml-jaxrs-codegen project and found an issue with the PathParam generation.

Let's say my RAML file has the following URIs:

```
/posts:
  /{post-id}:
```

In the generated interface, the method corresponding to the {post-id} will not contain a PathParam.

This issue stems from a class in the raml-java-parser project -- to be specific, the class "org.raml.parser.rule.BaseUriRule" and the "URI_PATTERN" regular expression.
w corresponds to `[A-Za-z0-9_]`
but this does not include the character -

The URI_PATTERN regular expression is used in the class "org.raml.parser.visitor.RamlDocumentBuilder" to parse out the Uri Parameters.
