### PR TITLE
use LinkedHashMaps to preserve RAML file order

### DIFF
--- a/src/main/java/org/raml/model/Resource.java
+++ b/src/main/java/org/raml/model/Resource.java
@@ -52,7 +52,7 @@ public class Resource implements Serializable
     private String relativeUri;
 
     @Mapping
-    private Map<String, UriParameter> uriParameters = new HashMap<String, UriParameter>();
+    private Map<String, UriParameter> uriParameters = new LinkedHashMap<String, UriParameter>();
 
     @Scalar
     private String type;
@@ -64,13 +64,13 @@ public class Resource implements Serializable
     private List<SecurityReference> securedBy = new ArrayList<SecurityReference>();
 
     @Mapping(rule = org.raml.parser.rule.UriParametersRule.class)
-    private Map<String, List<UriParameter>> baseUriParameters = new HashMap<String, List<UriParameter>>();
+    private Map<String, List<UriParameter>> baseUriParameters = new LinkedHashMap<String, List<UriParameter>>();
 
     @Mapping(implicit = true)
     private Map<ActionType, Action> actions = new LinkedHashMap<ActionType, Action>();
 
     @Mapping(handler = ResourceHandler.class, implicit = true)
-    private Map<String, Resource> resources = new HashMap<String, Resource>();
+    private Map<String, Resource> resources = new LinkedHashMap<String, Resource>();
 
     public Resource()
     {
@@ -169,7 +169,7 @@ public class Resource implements Serializable
     {
         if (parentResource != null)
         {
-            Map<String, UriParameter> uriParams = new HashMap<String, UriParameter>(parentResource.getUriParameters());
+            Map<String, UriParameter> uriParams = new LinkedHashMap<String, UriParameter>(parentResource.getUriParameters());
             uriParams.putAll(uriParameters);
             return uriParams;
         }


### PR DESCRIPTION
replace HashMaps with LinkedHashMaps so that model elements such as resources are ordered as in the RAML file
