### PR TITLE
upgrade to snakeyaml 1.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.13</version>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/org/raml/parser/utils/NodeUtils.java
+++ b/src/main/java/org/raml/parser/utils/NodeUtils.java
@@ -34,7 +34,6 @@ public class NodeUtils
     private static Set STANDARD_TAGS = new HashSet(
             Arrays.asList(new Tag[] {
                     Tag.YAML,
-                    Tag.VALUE,
                     Tag.MERGE,
                     Tag.SET,
                     Tag.PAIRS,


### PR DESCRIPTION
The parser is not compatible with snakeyaml 1.14 because they removed Tag.VALUE
This is problematic for spring projects that depend on snakeyaml 1.14