### PR TITLE
Make JSON Schema v4 as default

### DIFF
--- a/src/main/java/org/raml/parser/rule/SchemaRule.java
+++ b/src/main/java/org/raml/parser/rule/SchemaRule.java
@@ -48,7 +48,7 @@ import org.yaml.snakeyaml.nodes.Tag;
 public class SchemaRule extends SimpleRule
 {
 
-    private static final SyntaxValidator VALIDATOR = new SyntaxValidator(ValidationConfiguration.newBuilder().setDefaultVersion(SchemaVersion.DRAFTV3).freeze());
+    private static final SyntaxValidator VALIDATOR = new SyntaxValidator(ValidationConfiguration.newBuilder().setDefaultVersion(SchemaVersion.DRAFTV4).freeze());
 
     public SchemaRule()
     {


### PR DESCRIPTION
Update the default JSON Schema Validator to use draft v4 as the default if a specific version is not specified in the schema. Issue #56 