### PR TITLE
Fixing inability to handle schema node if RAML file did not contain global schemas section

### DIFF
--- a/src/main/java/org/raml/parser/rule/SchemaRule.java
+++ b/src/main/java/org/raml/parser/rule/SchemaRule.java
@@ -164,6 +164,9 @@ public class SchemaRule extends SimpleRule
     private ScalarNode getGlobalSchemaNode(String key)
     {
         GlobalSchemasRule schemasRule = (GlobalSchemasRule) getRootTupleRule().getRuleByFieldName("schemas");
+        if (schemasRule==null){
+        	return null;
+        }
         return schemasRule.getSchema(key);
     }
 


### PR DESCRIPTION
Currently RAML parser will break if RAML file did not contains global schemas section however spec did not requires this section and some
and it causes  https://github.com/mulesoft/raml-for-jax-rs/issues/47