### PR TITLE
Fix merging media type

### DIFF
--- a/src/main/java/org/raml/parser/visitor/MediaTypeResolver.java
+++ b/src/main/java/org/raml/parser/visitor/MediaTypeResolver.java
@@ -150,16 +150,18 @@ public class MediaTypeResolver
             	
             	if (targetTouple!=null){
             		List<NodeTuple> targetSubTuples = ((MappingNode)targetTouple.getValueNode()).getValue();
-            		boolean containsSuchKey = false;
+            		
+            		NodeTuple existingTuple = null;
             		for (NodeTuple targetSubTuple: targetSubTuples){
             			if(mediaTypeKey.equals(((ScalarNode)targetSubTuple.getKeyNode()).getValue())){
-            				containsSuchKey = true;
-            				break;
+            				existingTuple = targetSubTuple;
+            				break;            				
             			}
             		}
-            		if (!containsSuchKey){
-            			targetSubTuples.add(sourceTuple);
+            		if (existingTuple!=null){
+            			targetSubTuples.remove(existingTuple);
             		}
+            		targetSubTuples.add(sourceTuple);
 	          	}
 	        }
     	}

--- a/src/test/java/org/raml/parser/builder/DefaultMediaTypeTestCase.java
+++ b/src/test/java/org/raml/parser/builder/DefaultMediaTypeTestCase.java
@@ -17,6 +17,7 @@ package org.raml.parser.builder;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.raml.model.ActionType.GET;
@@ -123,4 +124,19 @@ public class DefaultMediaTypeTestCase extends AbstractRamlTestCase
         assertThat(raml2.getResources().get("/simple").getActions().size(),
                    is(raml1.getResources().get("/simple").getActions().size()));
     }
+    
+    @Test
+    public void merged()
+    {
+        Resource resource = raml.getResource("/merged");
+        Map<String, MimeType> getResponseBody = resource.getAction(ActionType.GET).getResponses().get("200").getBody();
+        assertThat(getResponseBody.size(), is(2));
+        assertThat(getResponseBody.containsKey("application/json"), is(true));
+        assertThat(getResponseBody.get("application/json").getSchema(), notNullValue());
+        assertThat(getResponseBody.get("application/json").getExample(), notNullValue());
+        assertThat(getResponseBody.containsKey("text/html"), is(true));
+        assertThat(getResponseBody.get("text/html").getSchema(), nullValue());
+        assertThat(getResponseBody.get("text/html").getExample(), notNullValue());
+    }
+
 }

--- a/src/test/java/org/raml/parser/builder/DefaultMediaTypeTestCase.java
+++ b/src/test/java/org/raml/parser/builder/DefaultMediaTypeTestCase.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.commons.io.IOUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.internal.matchers.NotNull;
 import org.raml.model.ActionType;
 import org.raml.model.MimeType;
 import org.raml.model.Raml;
@@ -93,6 +94,42 @@ public class DefaultMediaTypeTestCase extends AbstractRamlTestCase
         Resource resource = raml.getResource("/empty");
         assertThat(resource.getAction(PUT).getBody().size(), is(1));
         assertThat(resource.getAction(PUT).getResponses().get("200").getBody().size(), is(1));
+    }
+    
+    @Test
+    public void mergedWithType()
+    {
+        Resource resource = raml.getResource("/mergedWithType");
+        Map<String, MimeType> getResponseBody = resource.getAction(ActionType.GET).getResponses().get("200").getBody();
+        assertThat(getResponseBody.size(), is(2));
+        
+        assertThat(getResponseBody.containsKey("application/json"), is(true));
+        MimeType applicationJson = getResponseBody.get("application/json");
+        assertThat(applicationJson.getSchema(), notNullValue());
+        assertThat(applicationJson.getSchema().contains("merged"), is(true));
+        assertThat(applicationJson.getExample(), notNullValue());
+        assertThat(applicationJson.getExample().contains("foo"), is(true));
+        
+        assertThat(getResponseBody.containsKey("text/html"), is(true));
+        MimeType textHtml = getResponseBody.get("text/html");
+        assertThat(textHtml.getSchema(), nullValue());
+        assertThat(textHtml.getExample(), notNullValue());
+        assertThat(textHtml.getExample().contains("dummy resource example"), is(true));
+    }
+    
+    @Test
+    public void merged()
+    {
+        Resource resource = raml.getResource("/merged");
+        Map<String, MimeType> getResponseBody = resource.getAction(ActionType.GET).getResponses().get("200").getBody();
+        assertThat(getResponseBody.size(), is(1));
+        
+        assertThat(getResponseBody.containsKey("application/json"), is(false));
+        assertThat(getResponseBody.containsKey("text/html"), is(true));
+
+        MimeType textHtml = getResponseBody.get("text/html");
+        assertThat(textHtml.getSchema().contains("merged"), is(true));
+        assertThat(textHtml.getExample(), nullValue());
     }
 
     @Test

--- a/src/test/java/org/raml/parser/builder/DefaultMediaTypeTestCase.java
+++ b/src/test/java/org/raml/parser/builder/DefaultMediaTypeTestCase.java
@@ -125,18 +125,25 @@ public class DefaultMediaTypeTestCase extends AbstractRamlTestCase
                    is(raml1.getResources().get("/simple").getActions().size()));
     }
     
-    @Test
+  @Test
     public void merged()
     {
         Resource resource = raml.getResource("/merged");
         Map<String, MimeType> getResponseBody = resource.getAction(ActionType.GET).getResponses().get("200").getBody();
         assertThat(getResponseBody.size(), is(2));
+        
         assertThat(getResponseBody.containsKey("application/json"), is(true));
-        assertThat(getResponseBody.get("application/json").getSchema(), notNullValue());
-        assertThat(getResponseBody.get("application/json").getExample(), notNullValue());
+        MimeType applicationJson = getResponseBody.get("application/json");
+        assertThat(applicationJson.getSchema(), notNullValue());
+        assertThat(applicationJson.getSchema().contains("merged"), is(true));
+        assertThat(applicationJson.getExample(), notNullValue());
+        assertThat(applicationJson.getExample().contains("foo"), is(true));
+        
         assertThat(getResponseBody.containsKey("text/html"), is(true));
-        assertThat(getResponseBody.get("text/html").getSchema(), nullValue());
-        assertThat(getResponseBody.get("text/html").getExample(), notNullValue());
+        MimeType textHtml = getResponseBody.get("text/html");
+        assertThat(textHtml.getSchema(), nullValue());
+        assertThat(textHtml.getExample(), notNullValue());
+        assertThat(textHtml.getExample().contains("dummy resource example"), is(true));
     }
 
 }

--- a/src/test/java/org/raml/parser/builder/DefaultMediaTypeTestCase.java
+++ b/src/test/java/org/raml/parser/builder/DefaultMediaTypeTestCase.java
@@ -161,26 +161,5 @@ public class DefaultMediaTypeTestCase extends AbstractRamlTestCase
         assertThat(raml2.getResources().get("/simple").getActions().size(),
                    is(raml1.getResources().get("/simple").getActions().size()));
     }
-    
-  @Test
-    public void merged()
-    {
-        Resource resource = raml.getResource("/merged");
-        Map<String, MimeType> getResponseBody = resource.getAction(ActionType.GET).getResponses().get("200").getBody();
-        assertThat(getResponseBody.size(), is(2));
-        
-        assertThat(getResponseBody.containsKey("application/json"), is(true));
-        MimeType applicationJson = getResponseBody.get("application/json");
-        assertThat(applicationJson.getSchema(), notNullValue());
-        assertThat(applicationJson.getSchema().contains("merged"), is(true));
-        assertThat(applicationJson.getExample(), notNullValue());
-        assertThat(applicationJson.getExample().contains("foo"), is(true));
-        
-        assertThat(getResponseBody.containsKey("text/html"), is(true));
-        MimeType textHtml = getResponseBody.get("text/html");
-        assertThat(textHtml.getSchema(), nullValue());
-        assertThat(textHtml.getExample(), notNullValue());
-        assertThat(textHtml.getExample().contains("dummy resource example"), is(true));
-    }
-
+   
 }

--- a/src/test/resources/org/raml/media-type.yaml
+++ b/src/test/resources/org/raml/media-type.yaml
@@ -32,6 +32,26 @@ resourceTypes:
         type: typeParent
         put:
             is: [traitOne]
+    - dummy:
+        get:
+            responses:
+                200:
+                    body:
+                        example: |
+                               {
+                                 "id": "foo"
+                               }
+                        application/json:
+                            schema: |
+                               {  "$schema": "http://json-schema.org/draft-03/schema",
+                                   "type": "object",
+                                   "description": "A dummy schema",
+                                   "properties": {
+                                     "id":  { "type": "string" }
+                                   }
+                                }
+                        text/html:
+                            example: dummy resource example
 
 /simple:
     type: typeChild
@@ -57,3 +77,18 @@ resourceTypes:
     get:
         responses:
             200:
+
+/merged:
+    type: dummy
+    get:
+        responses:
+            200:
+              body:
+                schema: |
+                   {  "$schema": "http://json-schema.org/draft-03/schema",
+                      "type": "object",
+                      "description": "A merged schema",
+                      "properties": {
+                        "id":  { "type": "string" }
+                      }
+                   }

--- a/src/test/resources/org/raml/media-type.yaml
+++ b/src/test/resources/org/raml/media-type.yaml
@@ -79,6 +79,21 @@ resourceTypes:
             200:
 
 /merged:
+    get:
+        responses:
+            200:
+              body:
+                text/html:
+                  schema: |
+                     {  "$schema": "http://json-schema.org/draft-03/schema",
+                        "type": "object",
+                        "description": "A merged schema",
+                        "properties": {
+                          "id":  { "type": "string" }
+                        }
+                     }
+
+/mergedWithType:
     type: dummy
     get:
         responses:
@@ -92,3 +107,4 @@ resourceTypes:
                         "id":  { "type": "string" }
                       }
                    }
+                   


### PR DESCRIPTION
We have noticed that there is a bug in current raml-java-parser:

In case the resource action has the schema specified right under the body, without specifying the media type (so the dedfault media type applies), and at the same type a resource type is applied to the whole resource, where media-type specific schemas are defined, the schemas are merged in such a way that the RAML becomes invalid, and it is not possible to be parsed. The parsing fails with an exception.

For example:

    title: Example API
    version: v1
    mediaType: application/json

    resourceTypes:
        - dummy:
            get:
                responses:
                    200:
                        body:                    
                            application/json:
                                schema: |
                                   {  "$schema": "http://json-schema.org/draft-03/schema",
                                       "type": "object",
                                       "description": "A dummy schema",
                                       "properties": {
                                         "id":  { "type": "string" }
                                       }
                                    }

    /mergedWithType:
        type: dummy
        get:
            responses:
                200:
                  body:
                    schema: |
                       {  "$schema": "http://json-schema.org/draft-03/schema",
                          "type": "object",
                          "description": "A merged schema",
                          "properties": {
                            "id":  { "type": "string" }
                          }
                       }

will be merged into:

    /mergedWithType:
        type: dummy
        get:
            responses:
                200:
                  body:
                    application/json:
                        schema: |
                           {  "$schema": "http://json-schema.org/draft-03/schema",
                              "type": "object",
                              "description": "A merged schema",
                              "properties": {
                                "id":  { "type": "string" }
                              }
                           }
                        application/json:
                            schema: |
                              {  "$schema": "http://json-schema.org/draft-03/schema",
                                  "type": "object",
                                  "description": "A dummy schema",
                                  "properties": {
                                   "id":  { "type": "string" }
                               }
                             }

which is invalid.

Please check the  src/test/resources/org/raml/media-type.yaml file below for this error case, I added a test for that, and a possible solution. 

It should be however reviewed whether the order of schemas being applied is correct, ie which schema should have precedence over which, in case the schema specified on the resource is different from the schema defined in the resource type. Same applies to 'example' and 'formParameters'. You can see in the test which order is applied currently.
