### PR TITLE
Ignore invalid keys in the parser

### DIFF
--- a/src/main/java/org/raml/parser/builder/DefaultTupleBuilder.java
+++ b/src/main/java/org/raml/parser/builder/DefaultTupleBuilder.java
@@ -65,7 +65,7 @@ public class DefaultTupleBuilder<K extends Node, V extends Node> implements Tupl
                 return tupleBuilder;
             }
         }
-        throw new RuntimeException("Builder not found for " + tuple);
+        return null;
     }
 
     protected Map<String, TupleBuilder<?, ?>> getBuilders()

--- a/src/main/java/org/raml/parser/visitor/YamlDocumentBuilder.java
+++ b/src/main/java/org/raml/parser/visitor/YamlDocumentBuilder.java
@@ -270,6 +270,10 @@ public class YamlDocumentBuilder<T> implements NodeHandler, ContextPathAware
         if (currentBuilder != null)
         {
             NodeBuilder<?> builder = currentBuilder.getBuilderForTuple(nodeTuple);
+            if (builder == null)
+            {
+                return false;
+            }
             builderContext.push(builder);
         }
         else

--- a/src/main/java/org/raml/parser/visitor/YamlDocumentSuggester.java
+++ b/src/main/java/org/raml/parser/visitor/YamlDocumentSuggester.java
@@ -307,7 +307,11 @@ public class YamlDocumentSuggester implements NodeHandler
     {
         try
         {
-            builder.onTupleStart(nodeTuple);
+            boolean found = builder.onTupleStart(nodeTuple);
+            if (!found)
+            {
+                return false;
+            }
             MappingNode mapping = nodeTuple.getValueNode().getNodeId() == NodeId.mapping ? (MappingNode) nodeTuple.getValueNode() : null;
             pushNode(nodeTuple.getKeyNode(), mapping);
         }

--- a/src/test/java/org/raml/validation/ValidationTestCase.java
+++ b/src/test/java/org/raml/validation/ValidationTestCase.java
@@ -16,6 +16,7 @@
 package org.raml.validation;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.matchers.JUnitMatchers.containsString;
@@ -28,11 +29,13 @@ import java.util.List;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.raml.model.ActionType;
 import org.raml.model.Raml;
 import org.raml.parser.builder.AbstractRamlTestCase;
 import org.raml.parser.rule.ValidationResult;
 import org.raml.parser.tagresolver.ContextPath;
 import org.raml.parser.visitor.IncludeInfo;
+import org.raml.parser.visitor.RamlDocumentBuilder;
 
 public class ValidationTestCase extends AbstractRamlTestCase
 {
@@ -220,6 +223,21 @@ public class ValidationTestCase extends AbstractRamlTestCase
         includeInfo = includeContext.pop();
         assertThat(includeInfo.getIncludeName(), containsString("circular1.raml"));
         assertThat(includeInfo.getLine() + 1, is(3));
+    }
+
+    @Test
+    public void unknownKey()
+    {
+        String resource = "org/raml/validation/unknown-key.yaml";
+        
+        // validation reports the unknown key...
+        List<ValidationResult> validationResults = validateRaml(resource);
+        assertThat(validationResults.size(), is(1));
+        assertThat(validationResults.get(0).getMessage(), is("Unknown key: unknown"));
+        
+        // ... but the parser doesn't choke on it
+        Raml validContent = new RamlDocumentBuilder().build(resource);
+        assertThat(validContent.getResource("/partiallyInvalid").getAction(ActionType.POST), is(notNullValue()));
     }
 
     @Test

--- a/src/test/resources/org/raml/validation/unknown-key.yaml
+++ b/src/test/resources/org/raml/validation/unknown-key.yaml
@@ -1,0 +1,7 @@
+#%RAML 0.8
+title: unknown key
+/partiallyInvalid:
+    post:
+        unknown:
+        body:
+            application/json:


### PR DESCRIPTION
The validator already detects invalid keys, so the parser doesn't need
to report them by throwing an exception. This allows to read the valid
parts from an invalid RAML file.

This fixes issue #86 