### PR TITLE
Replacing the commons-validator dependency with commons-beanutils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,9 +223,9 @@
             <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>commons-validator</groupId>
-            <artifactId>commons-validator</artifactId>
-            <version>1.3.1</version>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Fix #75 