### PR TITLE
Fixing error finding items in array types containing unions

### DIFF
--- a/raml-parser-2/src/test/resources/org/raml/v2/api/v10/array-union-type/input.raml
+++ b/raml-parser-2/src/test/resources/org/raml/v2/api/v10/array-union-type/input.raml
@@ -1,0 +1,22 @@
+#%RAML 1.0
+title: simple object
+types:
+  Person:
+    properties:
+      name: string
+      email:
+        type: string
+        pattern: ^.+@.+\..+$
+      age:
+        type: integer
+        minimum: 0
+  Robot:
+    properties:
+      name: string
+      email:
+        type: string
+        pattern: ^.+@.+\..+$
+  Office:
+    type: object
+    properties:
+      workers: (Person | Robot)[]

--- a/raml-parser-2/src/test/resources/org/raml/v2/api/v10/array-union-type/model.json
+++ b/raml-parser-2/src/test/resources/org/raml/v2/api/v10/array-union-type/model.json
@@ -1,0 +1,229 @@
+{
+ "annotationTypes": [],
+ "annotations": [],
+ "baseUri": null,
+ "baseUriParameters": [],
+ "documentation": [],
+ "mediaType": [],
+ "protocols": [],
+ "ramlVersion": "1.0",
+ "resourceTypes": [],
+ "resources": [],
+ "schemas": [],
+ "securedBy": [],
+ "securitySchemes": [],
+ "title": {
+  "annotations": [],
+  "value": "simple object"
+ },
+ "traits": [],
+ "types": [
+  {
+   "additionalProperties": true,
+   "allowedTargets": [],
+   "annotations": [],
+   "defaultValue": null,
+   "description": null,
+   "discriminator": null,
+   "discriminatorValue": null,
+   "displayName": {
+    "annotations": [],
+    "value": "Person"
+   },
+   "example": null,
+   "examples": [],
+   "maxProperties": null,
+   "minProperties": null,
+   "name": "Person",
+   "properties": [
+    {
+     "allowedTargets": [],
+     "annotations": [],
+     "defaultValue": null,
+     "description": null,
+     "displayName": {
+      "annotations": [],
+      "value": "name"
+     },
+     "enumValues": [],
+     "example": null,
+     "examples": [],
+     "maxLength": null,
+     "minLength": null,
+     "name": "name",
+     "pattern": null,
+     "required": true,
+     "toXmlSchema": "<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" attributeFormDefault=\"unqualified\" elementFormDefault=\"unqualified\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\n    <element name=\"name\">\n        <simpleType>\n            <restriction base=\"string\"/>\n        </simpleType>\n    </element>\n</schema>\n",
+     "xml": null
+    },
+    {
+     "allowedTargets": [],
+     "annotations": [],
+     "defaultValue": null,
+     "description": null,
+     "displayName": {
+      "annotations": [],
+      "value": "email"
+     },
+     "enumValues": [],
+     "example": null,
+     "examples": [],
+     "maxLength": null,
+     "minLength": null,
+     "name": "email",
+     "pattern": "^.+@.+\\..+$",
+     "required": true,
+     "toXmlSchema": "<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" attributeFormDefault=\"unqualified\" elementFormDefault=\"unqualified\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\n    <element name=\"email\">\n        <simpleType>\n            <restriction base=\"string\">\n                <pattern value=\"^.+@.+\\..+$\"/>\n            </restriction>\n        </simpleType>\n    </element>\n</schema>\n",
+     "xml": null
+    },
+    {
+     "allowedTargets": [],
+     "annotations": [],
+     "defaultValue": null,
+     "description": null,
+     "displayName": {
+      "annotations": [],
+      "value": "age"
+     },
+     "enumValues": [],
+     "example": null,
+     "examples": [],
+     "format": null,
+     "maximum": null,
+     "minimum": 0.0,
+     "multipleOf": null,
+     "name": "age",
+     "required": true,
+     "toXmlSchema": "<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" attributeFormDefault=\"unqualified\" elementFormDefault=\"unqualified\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\n    <element name=\"age\">\n        <simpleType>\n            <restriction base=\"integer\">\n                <minInclusive value=\"0\"/>\n            </restriction>\n        </simpleType>\n    </element>\n</schema>\n",
+     "xml": null
+    }
+   ],
+   "required": true,
+   "toXmlSchema": "<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" attributeFormDefault=\"unqualified\" elementFormDefault=\"unqualified\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\n    <element name=\"Person\" type=\"Person\"/>\n    <complexType name=\"Person\">\n        <choice>\n            <element name=\"name\">\n                <simpleType>\n                    <restriction base=\"string\"/>\n                </simpleType>\n            </element>\n            <element name=\"email\">\n                <simpleType>\n                    <restriction base=\"string\">\n                        <pattern value=\"^.+@.+\\..+$\"/>\n                    </restriction>\n                </simpleType>\n            </element>\n            <element name=\"age\">\n                <simpleType>\n                    <restriction base=\"integer\">\n                        <minInclusive value=\"0\"/>\n                    </restriction>\n                </simpleType>\n            </element>\n            <any maxOccurs=\"unbounded\" minOccurs=\"0\"/>\n        </choice>\n    </complexType>\n</schema>\n",
+   "xml": null
+  },
+  {
+   "additionalProperties": true,
+   "allowedTargets": [],
+   "annotations": [],
+   "defaultValue": null,
+   "description": null,
+   "discriminator": null,
+   "discriminatorValue": null,
+   "displayName": {
+    "annotations": [],
+    "value": "Robot"
+   },
+   "example": null,
+   "examples": [],
+   "maxProperties": null,
+   "minProperties": null,
+   "name": "Robot",
+   "properties": [
+    {
+     "allowedTargets": [],
+     "annotations": [],
+     "defaultValue": null,
+     "description": null,
+     "displayName": {
+      "annotations": [],
+      "value": "name"
+     },
+     "enumValues": [],
+     "example": null,
+     "examples": [],
+     "maxLength": null,
+     "minLength": null,
+     "name": "name",
+     "pattern": null,
+     "required": true,
+     "toXmlSchema": "<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" attributeFormDefault=\"unqualified\" elementFormDefault=\"unqualified\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\n    <element name=\"name\">\n        <simpleType>\n            <restriction base=\"string\"/>\n        </simpleType>\n    </element>\n</schema>\n",
+     "xml": null
+    },
+    {
+     "allowedTargets": [],
+     "annotations": [],
+     "defaultValue": null,
+     "description": null,
+     "displayName": {
+      "annotations": [],
+      "value": "email"
+     },
+     "enumValues": [],
+     "example": null,
+     "examples": [],
+     "maxLength": null,
+     "minLength": null,
+     "name": "email",
+     "pattern": "^.+@.+\\..+$",
+     "required": true,
+     "toXmlSchema": "<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" attributeFormDefault=\"unqualified\" elementFormDefault=\"unqualified\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\n    <element name=\"email\">\n        <simpleType>\n            <restriction base=\"string\">\n                <pattern value=\"^.+@.+\\..+$\"/>\n            </restriction>\n        </simpleType>\n    </element>\n</schema>\n",
+     "xml": null
+    }
+   ],
+   "required": true,
+   "toXmlSchema": "<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" attributeFormDefault=\"unqualified\" elementFormDefault=\"unqualified\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\n    <element name=\"Robot\" type=\"Robot\"/>\n    <complexType name=\"Robot\">\n        <choice>\n            <element name=\"name\">\n                <simpleType>\n                    <restriction base=\"string\"/>\n                </simpleType>\n            </element>\n            <element name=\"email\">\n                <simpleType>\n                    <restriction base=\"string\">\n                        <pattern value=\"^.+@.+\\..+$\"/>\n                    </restriction>\n                </simpleType>\n            </element>\n            <any maxOccurs=\"unbounded\" minOccurs=\"0\"/>\n        </choice>\n    </complexType>\n</schema>\n",
+   "xml": null
+  },
+  {
+   "additionalProperties": true,
+   "allowedTargets": [],
+   "annotations": [],
+   "defaultValue": null,
+   "description": null,
+   "discriminator": null,
+   "discriminatorValue": null,
+   "displayName": {
+    "annotations": [],
+    "value": "Office"
+   },
+   "example": null,
+   "examples": [],
+   "maxProperties": null,
+   "minProperties": null,
+   "name": "Office",
+   "properties": [
+    {
+     "allowedTargets": [],
+     "annotations": [],
+     "defaultValue": null,
+     "description": null,
+     "displayName": {
+      "annotations": [],
+      "value": "workers"
+     },
+     "example": null,
+     "examples": [],
+     "items": {
+      "allowedTargets": [],
+      "annotations": [],
+      "defaultValue": null,
+      "description": null,
+      "displayName": {
+       "annotations": [],
+       "value": "workers"
+      },
+      "example": null,
+      "examples": [],
+      "name": "workers",
+      "required": true,
+      "toXmlSchema": "<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" attributeFormDefault=\"unqualified\" elementFormDefault=\"unqualified\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\n    <element name=\"workers\">\n        <complexType>\n            <choice>\n                <element name=\"name\">\n                    <simpleType>\n                        <restriction base=\"string\"/>\n                    </simpleType>\n                </element>\n                <element name=\"email\">\n                    <simpleType>\n                        <restriction base=\"string\">\n                            <pattern value=\"^.+@.+\\..+$\"/>\n                        </restriction>\n                    </simpleType>\n                </element>\n                <element name=\"age\">\n                    <simpleType>\n                        <restriction base=\"integer\">\n                            <minInclusive value=\"0\"/>\n                        </restriction>\n                    </simpleType>\n                </element>\n                <any maxOccurs=\"unbounded\" minOccurs=\"0\"/>\n            </choice>\n        </complexType>\n    </element>\n</schema>\n",
+      "xml": null
+     },
+     "maxItems": null,
+     "minItems": null,
+     "name": "workers",
+     "required": true,
+     "toXmlSchema": "<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" attributeFormDefault=\"unqualified\" elementFormDefault=\"unqualified\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\n    <element maxOccurs=\"unbounded\" name=\"workers\" type=\"Person\"/>\n    <complexType name=\"Person\">\n        <choice>\n            <element name=\"name\">\n                <simpleType>\n                    <restriction base=\"string\"/>\n                </simpleType>\n            </element>\n            <element name=\"email\">\n                <simpleType>\n                    <restriction base=\"string\">\n                        <pattern value=\"^.+@.+\\..+$\"/>\n                    </restriction>\n                </simpleType>\n            </element>\n            <element name=\"age\">\n                <simpleType>\n                    <restriction base=\"integer\">\n                        <minInclusive value=\"0\"/>\n                    </restriction>\n                </simpleType>\n            </element>\n            <any maxOccurs=\"unbounded\" minOccurs=\"0\"/>\n        </choice>\n    </complexType>\n</schema>\n",
+     "uniqueItems": null,
+     "xml": null
+    }
+   ],
+   "required": true,
+   "toXmlSchema": "<schema xmlns=\"http://www.w3.org/2001/XMLSchema\" attributeFormDefault=\"unqualified\" elementFormDefault=\"unqualified\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\n    <element name=\"Office\" type=\"Office\"/>\n    <complexType name=\"Office\">\n        <choice>\n            <element maxOccurs=\"unbounded\" name=\"workers\" type=\"Person\"/>\n            <any maxOccurs=\"unbounded\" minOccurs=\"0\"/>\n        </choice>\n    </complexType>\n    <complexType name=\"Person\">\n        <choice>\n            <element name=\"name\">\n                <simpleType>\n                    <restriction base=\"string\"/>\n                </simpleType>\n            </element>\n            <element name=\"email\">\n                <simpleType>\n                    <restriction base=\"string\">\n                        <pattern value=\"^.+@.+\\..+$\"/>\n                    </restriction>\n                </simpleType>\n            </element>\n            <element name=\"age\">\n                <simpleType>\n                    <restriction base=\"integer\">\n                        <minInclusive value=\"0\"/>\n                    </restriction>\n                </simpleType>\n            </element>\n            <any maxOccurs=\"unbounded\" minOccurs=\"0\"/>\n        </choice>\n    </complexType>\n</schema>\n",
+   "xml": null
+  }
+ ],
+ "uses": [],
+ "version": null
+}


### PR DESCRIPTION
This PR fixes a problem happening when an array type contains an union type.
In this case I found that invoking the ```items``` method just returns the array itself instead of the union within.

This clojure example shows the problem:

world_music.api/api.raml
```yaml
#%RAML 1.0
title: World Music API
baseUri: http://example.api.com/{version}
version: v1

uses:
  Songs: songs-library.raml

annotationTypes:
  monitoringInterval: integer

traits:
  secured: !include secured/accessToken.raml

/songs:
  is: [ secured ]
  get:
    (monitoringInterval): 30
    queryParameters:
      genre:
        description: filter the songs by genre
  post:
  /{songId}:
    get:
      responses:
        200:
          body:
            application/json:
              type: Songs.Musician
            application/xml:
              type: !include schemas/songs.xsd
              example: !include examples/songs.xml
```

world-music-api/songs-library.raml
```yaml
#%RAML 1.0 Library

types:
  Song:
    properties:
      title: string
      length: number
  Album:
    properties:
      title: string
      songs: Song[]
  Musician:
    properties:
      name: string
      discography: (Song | Album)[]
```
```clojure
(defn parse-raml [location]
  (let [raml-model-builder (RamlModelBuilder.)
        raml-result (.buildApi raml-model-builder location)]
    (or (.getApiV10 raml-result)
        (.getApiV08 raml-result))))

(def raml-api (parse-raml "/Users/antoniogarrote/Development/raml-examples/others/world-music-api/api.raml"))

(-> raml-api
    (.resources)
    first
    (.resources)
    first
    (.methods)
    first
    (.responses)
    first
    (.body)
    first
    (.properties)
    last
    (.items)
;; Here I would expect the union type
;;      (.of)

    (.items)
    (.items)
    (.items)
    ;; ...
    (.items))
```
I tried to fix the problem and the problem seems to be we are passing the type declaration for the array (in the example (Song | Album)[]) to the constructor of the `UnionResolvedType` class instead of the expression for the union. Then, when we try to get the items in `ArrayTypeDeclaration` we build the type of the array items using that same expression we get back from the union and the final outcome is an infinite series of arrays.

I tried to fix the problem building the right TypeDeclarationNode in the constructor of the `UnionResolvedType` class, but there might be a better approach.