### PR TITLE
Fixing issue that loses track of includes in resource types + traits

### DIFF
--- a/src/main/java/org/raml/parser/rule/SchemaRule.java
+++ b/src/main/java/org/raml/parser/rule/SchemaRule.java
@@ -17,6 +17,7 @@ package org.raml.parser.rule;
 
 import static org.raml.parser.rule.ValidationResult.UNKNOWN;
 import static org.raml.parser.rule.ValidationResult.createErrorResult;
+import static org.raml.parser.tagresolver.CompoundIncludeResolver.INCLUDE_COMPOUND_APPLIED_TAG;
 import static org.raml.parser.tagresolver.IncludeResolver.INCLUDE_APPLIED_TAG;
 import static org.raml.parser.tagresolver.IncludeResolver.IncludeScalarNode;
 
@@ -42,13 +43,16 @@ import org.raml.parser.ResolveResourceException;
 import org.raml.parser.XsdResourceResolver;
 import org.raml.parser.loader.ResourceLoader;
 import org.raml.parser.loader.ResourceLoaderAware;
+import org.raml.parser.tagresolver.CompoundIncludeResolver;
 import org.raml.parser.tagresolver.ContextPath;
 import org.raml.parser.tagresolver.ContextPathAware;
+import org.raml.parser.tagresolver.IncludeResolver;
 import org.raml.parser.utils.NodeUtils;
 import org.raml.parser.visitor.IncludeInfo;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.yaml.snakeyaml.nodes.ScalarNode;
+import org.yaml.snakeyaml.nodes.Tag;
 
 public class SchemaRule extends SimpleRule implements ContextPathAware, ResourceLoaderAware
 {
@@ -82,6 +86,16 @@ public class SchemaRule extends SimpleRule implements ContextPathAware, Resource
             {
                 globaSchemaIncludeInfo = new IncludeInfo(schemaNode.getTag());
                 actualContextPath = new ContextPath(globaSchemaIncludeInfo);
+            }
+            else if (schemaNode.getTag().startsWith(INCLUDE_COMPOUND_APPLIED_TAG))
+            {
+                List<IncludeInfo> appliedIncludeTags = CompoundIncludeResolver.unmarshall(schemaNode.getTag());
+                actualContextPath = new ContextPath();
+                for (IncludeInfo info : appliedIncludeTags)
+                {
+                    actualContextPath.push(info);
+                }
+                globaSchemaIncludeInfo = appliedIncludeTags.get(appliedIncludeTags.size() - 1);
             }
         }
         if (value == null || NodeUtils.isNonStringTag(schemaNode.getTag()))

--- a/src/main/java/org/raml/parser/tagresolver/CompoundIncludeResolver.java
+++ b/src/main/java/org/raml/parser/tagresolver/CompoundIncludeResolver.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 (c) MuleSoft, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.raml.parser.tagresolver;
+
+import static org.raml.parser.tagresolver.IncludeResolver.SEPARATOR;
+
+import java.util.List;
+
+import org.raml.parser.loader.ResourceLoader;
+import org.raml.parser.visitor.IncludeInfo;
+import org.raml.parser.visitor.NodeHandler;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.Tag;
+
+import com.google.common.collect.Lists;
+
+public class CompoundIncludeResolver implements TagResolver, ContextPathAware
+{
+
+    public static final String INCLUDE_COMPOUND_APPLIED_TAG = "!include-compound" + SEPARATOR;
+    private ContextPath contextPath;
+
+    public static List<IncludeInfo> unmarshall(Tag tag)
+    {
+        String compoundIncludeTag = tag.getValue().substring(INCLUDE_COMPOUND_APPLIED_TAG.length());
+
+        int endOfFirstLength = compoundIncludeTag.indexOf(SEPARATOR);
+        int firstIncludeLength = Integer.parseInt(compoundIncludeTag.substring(0, endOfFirstLength));
+        String firstAppliedInclude = compoundIncludeTag.substring(endOfFirstLength + 1, endOfFirstLength + 1 + firstIncludeLength);
+
+        IncludeInfo firstIncludeInfo = new IncludeInfo(new Tag(firstAppliedInclude));
+
+        String compoundIncludeTag1 = compoundIncludeTag.substring(endOfFirstLength + 1 + firstIncludeLength + 1);
+
+        int endOfSecondLength = compoundIncludeTag1.indexOf(SEPARATOR);
+        int secondIncludeLength = Integer.parseInt(compoundIncludeTag1.substring(0, endOfSecondLength));
+        String secondAppliedInclude = compoundIncludeTag1.substring(endOfSecondLength + 1, endOfSecondLength + 1 + secondIncludeLength);
+
+        IncludeInfo secondIncludeInfo = new IncludeInfo(new Tag(secondAppliedInclude));
+
+        return Lists.newArrayList(firstIncludeInfo, secondIncludeInfo);
+    }
+
+    @Override
+    public void setContextPath(ContextPath contextPath)
+    {
+        this.contextPath = contextPath;
+    }
+
+    @Override
+    public ContextPath getContextPath()
+    {
+        return contextPath;
+    }
+
+    @Override
+    public boolean handles(Tag tag)
+    {
+        return tag.startsWith(INCLUDE_COMPOUND_APPLIED_TAG);
+    }
+
+    @Override
+    public Node resolve(Node valueNode, ResourceLoader resourceLoader, NodeHandler nodeHandler)
+    {
+        return valueNode;
+    }
+
+    @Override
+    public void beforeProcessingResolvedNode(Tag tag, Node originalNode, Node resolvedNode)
+    {
+        if (tag.startsWith(INCLUDE_COMPOUND_APPLIED_TAG))
+        {
+            List<IncludeInfo> includes = unmarshall(tag);
+            for (IncludeInfo include : includes)
+            {
+                contextPath.push(include);
+            }
+        }
+    }
+
+    @Override
+    public void afterProcessingResolvedNode(Tag tag, Node originalNode, Node resolvedNode)
+    {
+        if (tag.startsWith(INCLUDE_COMPOUND_APPLIED_TAG))
+        {
+            List<IncludeInfo> includes = unmarshall(tag);
+            for (IncludeInfo include : includes)
+            {
+                contextPath.pop();
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/org/raml/parser/visitor/RamlDocumentBuilder.java
+++ b/src/main/java/org/raml/parser/visitor/RamlDocumentBuilder.java
@@ -32,6 +32,7 @@ import org.raml.model.parameter.UriParameter;
 import org.raml.parser.builder.NodeBuilder;
 import org.raml.parser.loader.DefaultResourceLoader;
 import org.raml.parser.loader.ResourceLoader;
+import org.raml.parser.tagresolver.CompoundIncludeResolver;
 import org.raml.parser.tagresolver.IncludeResolver;
 import org.raml.parser.tagresolver.JacksonTagResolver;
 import org.raml.parser.tagresolver.JaxbTagResolver;
@@ -58,6 +59,7 @@ public class RamlDocumentBuilder extends YamlDocumentBuilder<Raml>
     {
         TagResolver[] defaultResolvers = new TagResolver[] {
                 new IncludeResolver(),
+                new CompoundIncludeResolver(),
                 new JacksonTagResolver(),
                 new JaxbTagResolver()
         };

--- a/src/main/java/org/raml/parser/visitor/RamlValidationService.java
+++ b/src/main/java/org/raml/parser/visitor/RamlValidationService.java
@@ -22,6 +22,7 @@ import org.raml.parser.loader.DefaultResourceLoader;
 import org.raml.parser.loader.ResourceLoader;
 import org.raml.parser.rule.NodeRuleFactory;
 import org.raml.parser.rule.ValidationResult;
+import org.raml.parser.tagresolver.CompoundIncludeResolver;
 import org.raml.parser.tagresolver.IncludeResolver;
 import org.raml.parser.tagresolver.PojoValidatorTagResolver;
 import org.raml.parser.tagresolver.TagResolver;
@@ -39,6 +40,7 @@ public class RamlValidationService extends YamlValidationService
     {
         TagResolver[] defaultResolvers = new TagResolver[] {
                 new IncludeResolver(),
+                new CompoundIncludeResolver(),
                 new PojoValidatorTagResolver()
         };
         return (TagResolver[]) ArrayUtils.addAll(defaultResolvers, tagResolvers);

--- a/src/test/java/org/raml/validation/ValidationTestCase.java
+++ b/src/test/java/org/raml/validation/ValidationTestCase.java
@@ -294,4 +294,70 @@ public class ValidationTestCase extends AbstractRamlTestCase
         List<ValidationResult> validationResults = validateRaml(raml, "");
         assertThat(validationResults.size(), is(0));
     }
+
+    @Test
+    public void includedArrayOfIncludesMustReportErrorsInCorrectLocations()
+    {
+        String resource = "org/raml/validation/incorrect-location-api.raml";
+        List<ValidationResult> validationResults = validateRaml(resource);
+        assertThat(validationResults.size(), is(1));
+
+        ValidationResult validationResult = validationResults.get(0);
+        assertThat(validationResult.getMessage(), is("invalid JSON schema (files): Unrecognized token 'files': was expecting 'null', 'true', 'false' or NaN"));
+        assertThat(validationResult.getLine(), is(6));
+
+        ContextPath includeContext = validationResult.getIncludeContext();
+        assertThat(includeContext.size(), is(3));
+
+        IncludeInfo includeInfo = includeContext.pop();
+        assertThat(includeInfo.getIncludeName(), containsString("incorrect-location-collection.yaml"));
+        assertThat(includeInfo.getLine() + 1, is(1));
+
+        includeInfo = includeContext.pop();
+        assertThat(includeInfo.getIncludeName(), containsString("incorrect-location-resource-types.yaml"));
+        assertThat(includeInfo.getLine() + 1, is(4));
+    }
+    
+    @Test
+    public void inlineArrayOfIncludesMustReportErrorsInCorrectLocations()
+    {
+        String resource = "org/raml/validation/incorrect-location-2-api.raml";
+        List<ValidationResult> validationResults = validateRaml(resource);
+        assertThat(validationResults.size(), is(1));
+        
+        ValidationResult validationResult = validationResults.get(0);
+        assertThat(validationResult.getMessage(), is("invalid JSON schema (files): Unrecognized token 'files': was expecting 'null', 'true', 'false' or NaN"));
+        assertThat(validationResult.getLine(), is(6));
+        
+        ContextPath includeContext = validationResult.getIncludeContext();
+        assertThat(includeContext.size(), is(2));
+        
+        IncludeInfo includeInfo = includeContext.pop();
+        assertThat(includeInfo.getIncludeName(), containsString("incorrect-location-2-collection.yaml"));
+        assertThat(includeInfo.getLine() + 1, is(5));
+    }
+
+    @Test
+    public void includedArrayOfIncludesMustReportErrorsInCorrectLocationsForTraits()
+    {
+        String resource = "org/raml/validation/incorrect-location-3-api.raml";
+        List<ValidationResult> validationResults = validateRaml(resource);
+        assertThat(validationResults.size(), is(1));
+
+        ValidationResult validationResult = validationResults.get(0);
+        assertThat(validationResult.getMessage(), is("invalid JSON schema (files): Unrecognized token 'files': was expecting 'null', 'true', 'false' or NaN"));
+        assertThat(validationResult.getLine(), is(5));
+
+        ContextPath includeContext = validationResult.getIncludeContext();
+        assertThat(includeContext.size(), is(3));
+
+        IncludeInfo includeInfo = includeContext.pop();
+        assertThat(includeInfo.getIncludeName(), containsString("incorrect-location-3-collection.yaml"));
+        assertThat(includeInfo.getLine() + 1, is(1));
+
+        includeInfo = includeContext.pop();
+        assertThat(includeInfo.getIncludeName(), containsString("incorrect-location-3-traits.yaml"));
+        assertThat(includeInfo.getLine() + 1, is(4));
+    }
+
 }

--- a/src/test/resources/org/raml/validation/incorrect-location-2-api.raml
+++ b/src/test/resources/org/raml/validation/incorrect-location-2-api.raml
@@ -1,0 +1,8 @@
+#%RAML 0.8
+title:     error with locations
+
+resourceTypes:
+  - collection: !include incorrect-location-2-collection.yaml
+
+/files:
+  type: collection

--- a/src/test/resources/org/raml/validation/incorrect-location-2-collection.yaml
+++ b/src/test/resources/org/raml/validation/incorrect-location-2-collection.yaml
@@ -1,0 +1,6 @@
+get:
+  responses:
+    200:
+      body:
+        application/json:
+          schema: <<resourcePathName>>

--- a/src/test/resources/org/raml/validation/incorrect-location-3-api.raml
+++ b/src/test/resources/org/raml/validation/incorrect-location-3-api.raml
@@ -1,0 +1,8 @@
+#%RAML 0.8
+title:     error with locations
+
+traits: !include incorrect-location-3-traits.yaml
+
+/files:
+  get:
+    is: [ collection ]

--- a/src/test/resources/org/raml/validation/incorrect-location-3-collection.yaml
+++ b/src/test/resources/org/raml/validation/incorrect-location-3-collection.yaml
@@ -1,0 +1,5 @@
+responses:
+  200:
+    body:
+      application/json:
+        schema: <<resourcePathName>>

--- a/src/test/resources/org/raml/validation/incorrect-location-3-traits.yaml
+++ b/src/test/resources/org/raml/validation/incorrect-location-3-traits.yaml
@@ -1,0 +1,1 @@
+- collection:           !include incorrect-location-3-collection.yaml

--- a/src/test/resources/org/raml/validation/incorrect-location-api.raml
+++ b/src/test/resources/org/raml/validation/incorrect-location-api.raml
@@ -1,0 +1,7 @@
+#%RAML 0.8
+title:     error with locations
+
+resourceTypes: !include incorrect-location-resource-types.yaml
+
+/files:
+  type: collection

--- a/src/test/resources/org/raml/validation/incorrect-location-collection.yaml
+++ b/src/test/resources/org/raml/validation/incorrect-location-collection.yaml
@@ -1,0 +1,6 @@
+get:
+  responses:
+    200:
+      body:
+        application/json:
+          schema: <<resourcePathName>>

--- a/src/test/resources/org/raml/validation/incorrect-location-resource-types.yaml
+++ b/src/test/resources/org/raml/validation/incorrect-location-resource-types.yaml
@@ -1,0 +1,1 @@
+- collection:           !include incorrect-location-collection.yaml


### PR DESCRIPTION
This commit fixes an issue that made the parser/validation service lose tracks of includes when the `resourceTypes:` or `traits:` node at root level are composed of an included array at top level like the following:
**api.raml**

``` raml
#%RAML 0.8
title: my title
resourceTypes: !include resorceTypes.raml
/res:
  type: mytype
```

**resourceTypes.raml**

``` raml
- mytype: !include mytype.raml
```

**mytype.raml**

``` raml
get:
  body:
    application/json:
      schema: invalid-schema-ref
```

Which loses reference of the intermediate `resourceTypes.raml`.
