### PR TITLE
Fixing reference suggestions when multiple inherited types are defined

### DIFF
--- a/raml-parser-2/src/main/java/org/raml/v2/internal/impl/commons/suggester/ReferenceSuggester.java
+++ b/raml-parser-2/src/main/java/org/raml/v2/internal/impl/commons/suggester/ReferenceSuggester.java
@@ -89,22 +89,35 @@ public class ReferenceSuggester
             if (!child.getChildren().isEmpty())
             {
                 final String value = child.getChildren().get(0).toString();
-                final Node description = NodeSelector.selectFrom("usage", child.getChildren().get(1));
-                String descriptionText = "";
-                if (description != null)
+                final Node grandchild = child.getChildren().get(1);
+                
+                if (grandchild instanceof ArrayNode) // in case of a multiple inherited type
                 {
-                    descriptionText = description.toString();
+                    final List<Node> referenceNodes = grandchild.getChildren();
+                    for (Node referenceNode : referenceNodes)
+                    {
+                        collectReferenceNodeSuggestions(result, value, referenceNode);
+                    }   
                 }
                 else
                 {
-                    final Node usage = NodeSelector.selectFrom("description", child.getChildren().get(1));
-                    if (usage != null)
-                    {
-                        descriptionText = usage.toString();
-                    }
+                    collectReferenceNodeSuggestions(result, value, grandchild);
                 }
-                result.add(new DefaultSuggestion(value, descriptionText, value));
             }
         }
+    }
+
+    private void collectReferenceNodeSuggestions(List<Suggestion> result, String value, Node grandchild) {
+        final Node description = NodeSelector.selectFrom("usage", grandchild);
+        String descriptionText = "";
+        if (description != null) {
+            descriptionText = description.toString();
+        } else {
+            final Node usage = NodeSelector.selectFrom("description", grandchild);
+            if (usage != null) {
+                descriptionText = usage.toString();
+            }
+        }
+        result.add(new DefaultSuggestion(value, descriptionText, value));
     }
 }

--- a/raml-parser-2/src/test/resources/org/raml/v2/internal/framework/suggester/types/multiple-inheritance/input.raml
+++ b/raml-parser-2/src/test/resources/org/raml/v2/internal/framework/suggester/types/multiple-inheritance/input.raml
@@ -1,0 +1,8 @@
+#%RAML 1.0
+title: multiple inheritance suggestions
+
+types:       
+   Cat:
+   Animal: [ Cat ]
+   
+   NewType: <cursor>

--- a/raml-parser-2/src/test/resources/org/raml/v2/internal/framework/suggester/types/multiple-inheritance/output.json
+++ b/raml-parser-2/src/test/resources/org/raml/v2/internal/framework/suggester/types/multiple-inheritance/output.json
@@ -1,0 +1,81 @@
+[ {
+  "label" : "Animal",
+  "description" : "",
+  "value" : "Animal",
+  "prefix" : ""
+}, {
+  "label" : "Any",
+  "description" : "",
+  "value" : "any",
+  "prefix" : ""
+}, {
+  "label" : "Array",
+  "description" : "",
+  "value" : "array",
+  "prefix" : ""
+}, {
+  "label" : "Boolean",
+  "description" : "",
+  "value" : "boolean",
+  "prefix" : ""
+}, {
+  "label" : "Cat",
+  "description" : "",
+  "value" : "Cat",
+  "prefix" : ""
+}, {
+  "label" : "Date-only",
+  "description" : "",
+  "value" : "date-only",
+  "prefix" : ""
+}, {
+  "label" : "Datetime",
+  "description" : "",
+  "value" : "datetime",
+  "prefix" : ""
+}, {
+  "label" : "Datetime-only",
+  "description" : "",
+  "value" : "datetime-only",
+  "prefix" : ""
+}, {
+  "label" : "File",
+  "description" : "",
+  "value" : "file",
+  "prefix" : ""
+}, {
+  "label" : "Integer",
+  "description" : "",
+  "value" : "integer",
+  "prefix" : ""
+}, {
+  "label" : "NewType",
+  "description" : "",
+  "value" : "NewType",
+  "prefix" : ""
+}, {
+  "label" : "Nil",
+  "description" : "",
+  "value" : "nil",
+  "prefix" : ""
+}, {
+  "label" : "Number",
+  "description" : "",
+  "value" : "number",
+  "prefix" : ""
+}, {
+  "label" : "Object",
+  "description" : "",
+  "value" : "object",
+  "prefix" : ""
+}, {
+  "label" : "String",
+  "description" : "",
+  "value" : "string",
+  "prefix" : ""
+}, {
+  "label" : "Time-only",
+  "description" : "",
+  "value" : "time-only",
+  "prefix" : ""
+} ]


### PR DESCRIPTION
Currently the suggester breaks when asking for suggestions in a case like the following as it is not taking into account multiple inheritance type definitions:
```raml
#%RAML 1.0
title: multiple inheritance suggestions

types:       
   Cat:
   Animal: [ Cat ]

   NewType: <cursor>
```