### PR TITLE
Don't throw ResourceNotFoundException when RAML file does not exist

### DIFF
--- a/src/main/java/org/raml/parser/visitor/YamlValidationService.java
+++ b/src/main/java/org/raml/parser/visitor/YamlValidationService.java
@@ -70,10 +70,14 @@ public class YamlValidationService
     public List<ValidationResult> validate(String resourceLocation)
     {
         InputStream resourceStream = resourceLoader.fetchResource(resourceLocation);
+
         if (resourceStream == null)
         {
-            throw new ResourceNotFoundException(resourceLocation);
+            List<ValidationResult> results = new ArrayList<ValidationResult>();
+            results.add(ValidationResult.createErrorResult("RAML resource not found"));
+            return results;
         }
+
         return validate(resourceStream, resourceLocation);
     }
 

--- a/src/test/java/org/raml/ResourceNotFoundTestCase.java
+++ b/src/test/java/org/raml/ResourceNotFoundTestCase.java
@@ -18,6 +18,12 @@ package org.raml;
 import org.junit.Test;
 import org.raml.parser.builder.AbstractRamlTestCase;
 import org.raml.parser.loader.ResourceNotFoundException;
+import org.raml.parser.rule.ValidationResult;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class ResourceNotFoundTestCase extends AbstractRamlTestCase
 {
@@ -28,10 +34,12 @@ public class ResourceNotFoundTestCase extends AbstractRamlTestCase
         parseRaml("invalid/raml/resource.raml");
     }
 
-    @Test(expected = ResourceNotFoundException.class)
+    @Test
     public void resourceNotFoundOnValidation()
     {
-        validateRaml("invalid/raml/resource.raml");
+        List<ValidationResult> results = validateRaml("invalid/raml/resource.raml");
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getMessage(), is("RAML resource not found"));
     }
 
 }


### PR DESCRIPTION
Fixes #224