### PR TITLE
issues/310 fix included URI resolving

### DIFF
--- a/raml-parser-2/src/main/java/org/raml/v2/internal/utils/SchemaGenerator.java
+++ b/raml-parser-2/src/main/java/org/raml/v2/internal/utils/SchemaGenerator.java
@@ -78,27 +78,36 @@ public class SchemaGenerator
         // Getting the type holding the schema
         TypeExpressionNode typeDeclarationNode = jsonTypeDefinition.getTypeDeclarationNode();
 
-        // Inside the type declaration, we find the node containing the schema itself
-        List<ExternalSchemaTypeExpressionNode> schemas = typeDeclarationNode.findDescendantsWith(ExternalSchemaTypeExpressionNode.class);
-        if (schemas.size() > 0)
+        if (typeDeclarationNode instanceof ExternalSchemaTypeExpressionNode)
         {
-            return schemas.get(0).getStartPosition().getIncludedResourceUri();
+            ExternalSchemaTypeExpressionNode schema = (ExternalSchemaTypeExpressionNode) typeDeclarationNode;
+
+            return schema.getStartPosition().getIncludedResourceUri();
         }
         else
         {
-            // If the array is empty, then it must be a reference to a previously defined type
-            List<NamedTypeExpressionNode> refNode = typeDeclarationNode.findDescendantsWith(NamedTypeExpressionNode.class);
-
-            if (refNode.size() > 0)
+            // Inside the type declaration, we find the node containing the schema itself
+            List<ExternalSchemaTypeExpressionNode> schemas = typeDeclarationNode.findDescendantsWith(ExternalSchemaTypeExpressionNode.class);
+            if (schemas.size() > 0)
             {
-                // If refNodes is not empty, then we obtain that type
-                typeDeclarationNode = refNode.get(0).resolveReference();
-                if (typeDeclarationNode != null)
+                return schemas.get(0).getStartPosition().getIncludedResourceUri();
+            }
+            else
+            {
+                // If the array is empty, then it must be a reference to a previously defined type
+                List<NamedTypeExpressionNode> refNode = typeDeclarationNode.findDescendantsWith(NamedTypeExpressionNode.class);
+
+                if (refNode.size() > 0)
                 {
-                    schemas = typeDeclarationNode.findDescendantsWith(ExternalSchemaTypeExpressionNode.class);
-                    if (schemas.size() > 0)
+                    // If refNodes is not empty, then we obtain that type
+                    typeDeclarationNode = refNode.get(0).resolveReference();
+                    if (typeDeclarationNode != null)
                     {
-                        return schemas.get(0).getStartPosition().getIncludedResourceUri();
+                        schemas = typeDeclarationNode.findDescendantsWith(ExternalSchemaTypeExpressionNode.class);
+                        if (schemas.size() > 0)
+                        {
+                            return schemas.get(0).getStartPosition().getIncludedResourceUri();
+                        }
                     }
                 }
             }

--- a/raml-parser-2/src/test/java/org/raml/v2/internal/utils/SchemaGeneratorTest.java
+++ b/raml-parser-2/src/test/java/org/raml/v2/internal/utils/SchemaGeneratorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013 (c) MuleSoft, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
 package org.raml.v2.internal.utils;
 
 
@@ -23,16 +38,19 @@ import java.util.Collection;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
-public class SchemaGeneratorTest extends TestDataProvider {
-    private static final String SCHEMA_PATH = "schema.json";
-    private static final String EXAMPLE_PATH = "input.json";
+public class SchemaGeneratorTest extends TestDataProvider
+{
+    private static final String SCHEMA_FILE_NAME = "schema.json";
+    private static final String EXAMPLE_FILE_NAME = "input.json";
 
-    public SchemaGeneratorTest(File input, File expectedOutput, String name) {
+    public SchemaGeneratorTest(File input, File expectedOutput, String name)
+    {
         super(input, expectedOutput, name);
     }
 
     @Test
-    public void verifyJson() throws IOException, ProcessingException {
+    public void verifyJson() throws IOException, ProcessingException
+    {
         String content = IOUtils.toString(input.toURI());
         ExternalSchemaTypeExpressionNode node = new ExternalSchemaTypeExpressionNode(content);
         Position position = Mockito.mock(Position.class);
@@ -49,7 +67,8 @@ public class SchemaGeneratorTest extends TestDataProvider {
     }
 
     @Parameterized.Parameters(name = "{2}")
-    public static Collection<Object[]> getData() throws URISyntaxException {
-        return getData(SchemaGeneratorTest.class.getResource("").toURI(), SCHEMA_PATH, EXAMPLE_PATH);
+    public static Collection<Object[]> getData() throws URISyntaxException
+    {
+        return getData(SchemaGeneratorTest.class.getResource("").toURI(), SCHEMA_FILE_NAME, EXAMPLE_FILE_NAME);
     }
 }

--- a/raml-parser-2/src/test/java/org/raml/v2/internal/utils/SchemaGeneratorTest.java
+++ b/raml-parser-2/src/test/java/org/raml/v2/internal/utils/SchemaGeneratorTest.java
@@ -1,0 +1,55 @@
+package org.raml.v2.internal.utils;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.main.JsonSchema;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+import org.raml.v2.dataprovider.TestDataProvider;
+import org.raml.v2.internal.impl.commons.nodes.ExternalSchemaTypeExpressionNode;
+import org.raml.v2.internal.impl.commons.type.JsonSchemaExternalType;
+import org.raml.yagi.framework.nodes.Position;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class SchemaGeneratorTest extends TestDataProvider {
+    private static final String SCHEMA_PATH = "schema.json";
+    private static final String EXAMPLE_PATH = "input.json";
+
+    public SchemaGeneratorTest(File input, File expectedOutput, String name) {
+        super(input, expectedOutput, name);
+    }
+
+    @Test
+    public void verifyJson() throws IOException, ProcessingException {
+        String content = IOUtils.toString(input.toURI());
+        ExternalSchemaTypeExpressionNode node = new ExternalSchemaTypeExpressionNode(content);
+        Position position = Mockito.mock(Position.class);
+
+        Mockito.when(position.getIncludedResourceUri()).thenReturn(input.toURI().toString());
+        node.setStartPosition(position);
+        node.setEndPosition(position);
+
+        JsonSchemaExternalType jsonSchemaExternalType = (JsonSchemaExternalType) node.generateDefinition();
+        JsonSchema jsonSchema = SchemaGenerator.generateJsonSchema(jsonSchemaExternalType);
+        ProcessingReport report = jsonSchema.validate(new ObjectMapper().readTree(expectedOutput));
+
+        assertTrue(report.isSuccess());
+    }
+
+    @Parameterized.Parameters(name = "{2}")
+    public static Collection<Object[]> getData() throws URISyntaxException {
+        return getData(SchemaGeneratorTest.class.getResource("").toURI(), SCHEMA_PATH, EXAMPLE_PATH);
+    }
+}

--- a/raml-parser-2/src/test/resources/org/raml/v2/internal/utils/schema-generator-json/input.json
+++ b/raml-parser-2/src/test/resources/org/raml/v2/internal/utils/schema-generator-json/input.json
@@ -1,0 +1,3 @@
+{
+  "value": "hello"
+}

--- a/raml-parser-2/src/test/resources/org/raml/v2/internal/utils/schema-generator-json/schema-sub.json
+++ b/raml-parser-2/src/test/resources/org/raml/v2/internal/utils/schema-generator-json/schema-sub.json
@@ -1,0 +1,4 @@
+{
+  "description": "value",
+  "type": "string"
+}

--- a/raml-parser-2/src/test/resources/org/raml/v2/internal/utils/schema-generator-json/schema.json
+++ b/raml-parser-2/src/test/resources/org/raml/v2/internal/utils/schema-generator-json/schema.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "value": {
+      "$ref": "schema-sub.json"
+    }
+  }
+}


### PR DESCRIPTION
Fixed URI resolving in SchemaGenerator#resolveResourceUriIfIncluded
related [issue](https://github.com/raml-org/raml-java-parser/issues/310)

It looks like there is a missing case when `TypeExpressionNode typeDeclarationNode` is `ExternalSchemaTypeExpressionNode` so, in that case 
```
List<ExternalSchemaTypeExpressionNode> schemas = typeDeclarationNode.findDescendantsWith(ExternalSchemaTypeExpressionNode.class);
```
there will no child schemas with type  `ExternalSchemaTypeExpressionNode`

