### PR TITLE
Fixed issue with casting on error node in ErrorNode and AnnoationNode

### DIFF
--- a/raml-parser-2/src/main/java/org/raml/v2/internal/impl/commons/model/RamlValidationResult.java
+++ b/raml-parser-2/src/main/java/org/raml/v2/internal/impl/commons/model/RamlValidationResult.java
@@ -67,13 +67,13 @@ public class RamlValidationResult implements org.raml.v2.api.model.common.Valida
         return builder.toString();
     }
 
-    public Position getStart()
+    public Position getStartPosition()
     {
         return start;
     }
 
 
-    public Position getEnd()
+    public Position getEndPosition()
     {
         return end;
     }

--- a/raml-parser-2/src/main/java/org/raml/v2/internal/impl/commons/model/RamlValidationResult.java
+++ b/raml-parser-2/src/main/java/org/raml/v2/internal/impl/commons/model/RamlValidationResult.java
@@ -67,4 +67,16 @@ public class RamlValidationResult implements org.raml.v2.api.model.common.Valida
         return builder.toString();
     }
 
+    public Position getStart()
+    {
+        return start;
+    }
+
+
+    public Position getEnd()
+    {
+        return end;
+    }
+
+
 }

--- a/raml-parser-2/src/main/java/org/raml/v2/internal/impl/commons/nodes/AnnotationNode.java
+++ b/raml-parser-2/src/main/java/org/raml/v2/internal/impl/commons/nodes/AnnotationNode.java
@@ -61,7 +61,12 @@ public class AnnotationNode extends KeyValueNodeImpl implements OverlayableNode
     @Override
     public AnnotationReferenceNode getKey()
     {
-        return (AnnotationReferenceNode) super.getKey();
+        AnnotationReferenceNode node = null;
+        if (super.getKey() instanceof AnnotationReferenceNode)
+        {
+            node = (AnnotationReferenceNode) super.getKey();
+        }
+        return node;
     }
 
     public AnnotationTarget getTarget()

--- a/yagi/src/main/java/org/raml/yagi/framework/nodes/ErrorNode.java
+++ b/yagi/src/main/java/org/raml/yagi/framework/nodes/ErrorNode.java
@@ -52,8 +52,11 @@ public class ErrorNode extends AbstractRamlNode
                 else if (currentNode instanceof KeyValueNode)
                 {
                     Node key = ((KeyValueNode) currentNode).getKey();
-                    String currentKey = ((SimpleTypeNode) key).getLiteralValue().replace("/", "~1");
-                    keysStack.push(currentKey);
+                    if (key != null)
+                    {
+                        String currentKey = ((SimpleTypeNode) key).getLiteralValue().replace("/", "~1");
+                        keysStack.push(currentKey);
+                    }
                 }
                 previousNode = currentNode;
                 currentNode = currentNode.getParent();

--- a/yagi/src/main/java/org/raml/yagi/framework/nodes/ErrorNode.java
+++ b/yagi/src/main/java/org/raml/yagi/framework/nodes/ErrorNode.java
@@ -33,6 +33,7 @@ public class ErrorNode extends AbstractRamlNode
         return errorMessage;
     }
 
+
     public String getPath()
     {
         if (path == null)
@@ -82,6 +83,7 @@ public class ErrorNode extends AbstractRamlNode
     {
         return this;
     }
+
 
     @Override
     public NodeType getType()


### PR DESCRIPTION
Found a situation where the RAML parser would try to cast an ErrorNode to an AnnotationReferenceNode when parsing. Added a check to make sure that the type was an instance of the right class. Returns null if not.