### PR TITLE
Fixed visitDate and visitTime methods to return date only or time only

### DIFF
--- a/raml-parser-2/src/main/java/org/raml/v2/internal/impl/v10/type/TypeToJsonSchemaVisitor.java
+++ b/raml-parser-2/src/main/java/org/raml/v2/internal/impl/v10/type/TypeToJsonSchemaVisitor.java
@@ -42,6 +42,8 @@ public class TypeToJsonSchemaVisitor implements TypeVisitor<JsonObjectBuilder>
     private static final String INTEGER = "integer";
     private static final String NULL = "null";
     private static final String DATE_TIME = "date-time";
+    private static final String DATE_ONLY = "date";
+    private static final String TIME_ONLY = "time";
     private static final String STRING = "string";
     private static final String BOOLEAN = "boolean";
     private static final String ARRAY = "array";
@@ -177,7 +179,7 @@ public class TypeToJsonSchemaVisitor implements TypeVisitor<JsonObjectBuilder>
     {
         return this.factory.createObjectBuilder()
                            .add(TYPE, STRING)
-                           .add(FORMAT, DATE_TIME);
+                           .add(FORMAT, DATE_ONLY);
     }
 
     @Override
@@ -185,7 +187,7 @@ public class TypeToJsonSchemaVisitor implements TypeVisitor<JsonObjectBuilder>
     {
         return this.factory.createObjectBuilder()
                            .add(TYPE, STRING)
-                           .add(FORMAT, DATE_TIME);
+                           .add(FORMAT, TIME_ONLY);
     }
 
     @Override


### PR DESCRIPTION
Currently, parser works correctly with date-time only format, but do not respect date or time only while generating JSON schema. In any case it set date-time. Such behaviour causes an error in future when this schema is used for POJO generation (such as jsonschema2pojo library or Mulesoft libs) etc.

This PR is the fix for date and time only cases and there is no change for datetime-only case.

regards,
Eugene