### PR TITLE
:bug: Fix RamlEmitter#dump not adding quotes around security requirements scopes

### DIFF
--- a/src/main/java/org/raml/emitter/RamlEmitter.java
+++ b/src/main/java/org/raml/emitter/RamlEmitter.java
@@ -15,8 +15,6 @@
  */
 package org.raml.emitter;
 
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 import static org.raml.parser.utils.ReflectionUtils.isEnum;
 import static org.raml.parser.utils.ReflectionUtils.isPojo;
@@ -40,6 +38,7 @@ import org.raml.parser.annotation.Mapping;
 import org.raml.parser.annotation.Scalar;
 import org.raml.parser.annotation.Sequence;
 import org.raml.parser.utils.ReflectionUtils;
+import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
 
 public class RamlEmitter
 {
@@ -54,6 +53,9 @@ public class RamlEmitter
 
     private static final Pattern NO_QUOTES = Pattern.compile("^[a-zA-Z_/+][^:]*$");
     private static final String[] LITERALS = {"yes", "no", "true", "false", "on", "off", "null"};
+
+    final ParameterizedTypeImpl SCOPES_TYPE = ParameterizedTypeImpl
+            .make(List.class, new Type[]{String.class}, null);
 
     public String dump(Raml raml)
     {
@@ -184,7 +186,7 @@ public class RamlEmitter
             if (((SecurityReference) item).getParameters().size() > 0)
             {
                 dump.append(YAML_MAP_SEP).append("\n");
-                dumpMap(dump, depth + 2, String.class, ((SecurityReference) item).getParameters());
+                dumpMap(dump, depth + 2, SCOPES_TYPE, ((SecurityReference) item).getParameters());
             }
             else
             {
@@ -353,7 +355,7 @@ public class RamlEmitter
         }
         return field.getName();
     }
-    
+
 //    private boolean isBooleanOrInteger(Object value) {
 //        try {
 //            Long.valueOf(value.toString());

--- a/src/test/resources/org/raml/full-config.yaml
+++ b/src/test/resources/org/raml/full-config.yaml
@@ -110,7 +110,7 @@ traits:
 
 /:
     type: basic
-    securedBy: [oauth_2_0: { scopes: [ comments ] }, oauth_1_0, null]
+    securedBy: [oauth_2_0: { scopes: [ "comments:read" ] }, oauth_1_0, null]
     displayName: Root resource
     description: Root resource description
     head:


### PR DESCRIPTION
### Affects: [0.8.28](https://github.com/raml-org/raml-java-parser/tree/0.8.28)

### Issue

When dumping a RAML document that contains security requirements of type Oauth 2.0 with scopes that contain colons, the dumped RAML is not importable again. 

The import fails with an error that looks like this:

```
while scanning a plain scalar
 in 'reader', line 16, column 22:
                scopes: [read:pet, write:pet]
                         ^
found unexpected ':'
 in 'reader', line 16, column 26:
                scopes: [read:pet, write:pet]
                             ^
Please check http://pyyaml.org/wiki/YAMLColonInFlowContext for details.
```

### Analysis

The dumped scopes are not quoted by `RamlEmitter#dump` because the call to `RamlEmitter#dumpMap` done in `RamlEmitter#handleSecurityReference` states that the type of the values in `SecurityReference#parameters` is `String` where it really is `List<String>`.

Since the scopes are not quoted, the parser thinks the scopes are objects where they really are Strings. 

### How to reproduce

#### RAML file

```yaml
#%RAML 0.8
title: An API
version: "1.0.0"
baseUri: "http://myapi.io"
securitySchemes: 
    - 
        oauth2_scheme: 
            type: OAuth 2.0
            settings: 
                authorizationUri: "http://myapi.io/oauth/dialog"
                authorizationGrants: [token]
                scopes: ["read:toto", "write:toto"]
securedBy: 
    - 
        oauth2_scheme: 
             scopes: [ "read:toto" ]
```

#### Java file

```java
import org.junit.Test;
import org.raml.emitter.RamlEmitter;
import org.raml.model.Raml;
import org.raml.parser.visitor.RamlDocumentBuilder;

import java.io.StringReader;

public class TestScopesExport {
    @Test
    public void readWriteRead() {
        final Raml raml = new RamlDocumentBuilder().build("/PATH/TO/DEFINITION.raml");
        final String serializedRaml = new RamlEmitter().dump(raml);
        new RamlDocumentBuilder().build(new StringReader(serializedRaml));
    }
}
```
