### PR TITLE
Protocols in lowercase added to accomplish RAML 10 specs

### DIFF
--- a/raml-parser-2/src/main/java/org/raml/v2/internal/impl/v10/grammar/Raml10Grammar.java
+++ b/raml-parser-2/src/main/java/org/raml/v2/internal/impl/v10/grammar/Raml10Grammar.java
@@ -926,5 +926,11 @@ public class Raml10Grammar extends BaseRamlGrammar
     {
         return super.documentation().with(annotationField()).then(DocumentationItemNode.class);
     }
+    
+    protected Rule protocols()
+    {
+        AnyOfRule protocols = anyOf(string("HTTP"), string("HTTPS"), string("http"), string("https"));
+        return anyOf(protocols, array(protocols)).then(new ArrayWrapperFactory());
+    }
 
 }


### PR DESCRIPTION
you can check here
https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md
that "The protocols node MUST be a non-empty array of strings, of values
HTTP and/or HTTPS, and is case-insensitive."
 I'm working on an issue of "Anypoint Studio" and I need this fix to close it.