### PR TITLE
Fix path slash in windows.

### DIFF
--- a/raml-parser-2/src/main/java/org/raml/v2/internal/utils/ResourcePathUtils.java
+++ b/raml-parser-2/src/main/java/org/raml/v2/internal/utils/ResourcePathUtils.java
@@ -17,6 +17,7 @@ package org.raml.v2.internal.utils;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -55,8 +56,7 @@ public class ResourcePathUtils
                 }
                 else
                 {
-                    File resultFile = new File(result);
-                    result = resultFile.toPath().normalize().toString();
+                    result = Paths.get(result).normalize().toString().replace("\\", "/");
                 }
             }
         }


### PR DESCRIPTION
This PR fixes problem with slashes in windows. Which was originated in
https://github.com/raml-org/raml-java-parser/pull/589
