### PR TITLE
Update snakeyaml to 1.23 in raml-parser (0.8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <snakeyaml.version>1.15</snakeyaml.version>
+        <snakeyaml.version>1.23</snakeyaml.version>
     </properties>
 
     <build>

--- a/src/main/java/org/raml/parser/builder/TemplateBuilder.java
+++ b/src/main/java/org/raml/parser/builder/TemplateBuilder.java
@@ -82,7 +82,7 @@ public class TemplateBuilder extends SequenceTupleBuilder
     private Node getFakeTemplateNode(Node keyNode)
     {
         List<NodeTuple> innerTuples = new ArrayList<NodeTuple>();
-        innerTuples.add(new NodeTuple(new ScalarNode(Tag.STR, "description", null, null, null), keyNode));
+        innerTuples.add(new NodeTuple(new ScalarNode(Tag.STR, "description", null, null, (Character)null), keyNode));
         MappingNode innerNode = new MappingNode(Tag.MAP, innerTuples, false);
         List<NodeTuple> outerTuples = new ArrayList<NodeTuple>();
         outerTuples.add(new NodeTuple(keyNode, innerNode));

--- a/src/main/java/org/raml/parser/tagresolver/IncludeResolver.java
+++ b/src/main/java/org/raml/parser/tagresolver/IncludeResolver.java
@@ -128,7 +128,7 @@ public class IncludeResolver implements TagResolver, ContextPathAware
 
     private Node mockInclude(Node node)
     {
-        return new ScalarNode(INCLUDE_NOT_FOUND_TAG, "invalid", node.getStartMark(), node.getEndMark(), null);
+        return new ScalarNode(INCLUDE_NOT_FOUND_TAG, "invalid", node.getStartMark(), node.getEndMark(), (Character)null);
     }
 
     public void setContextPath(ContextPath contextPath)

--- a/src/main/java/org/raml/parser/visitor/MediaTypeResolver.java
+++ b/src/main/java/org/raml/parser/visitor/MediaTypeResolver.java
@@ -121,7 +121,7 @@ public class MediaTypeResolver
             }
         }
         List<NodeTuple> copy = new ArrayList<NodeTuple>(bodyNode.getValue());
-        Node keyNode = new ScalarNode(Tag.STR, mediaType, null, null, null);
+        Node keyNode = new ScalarNode(Tag.STR, mediaType, null, null, (Character)null);
         Node valueNode = new MappingNode(Tag.MAP, copy, false);
         bodyNode.getValue().clear();
         bodyNode.getValue().add(new NodeTuple(keyNode, valueNode));

--- a/src/main/java/org/raml/parser/visitor/TemplateResolver.java
+++ b/src/main/java/org/raml/parser/visitor/TemplateResolver.java
@@ -225,7 +225,7 @@ public class TemplateResolver
     private Node getFakeTemplateNode(Node keyNode)
     {
         List<NodeTuple> innerTuples = new ArrayList<NodeTuple>();
-        innerTuples.add(new NodeTuple(new ScalarNode(Tag.STR, "displayName", null, null, null), keyNode));
+        innerTuples.add(new NodeTuple(new ScalarNode(Tag.STR, "displayName", null, null, (Character)null), keyNode));
         MappingNode innerNode = new MappingNode(Tag.MAP, innerTuples, false);
         List<NodeTuple> outerTuples = new ArrayList<NodeTuple>();
         outerTuples.add(new NodeTuple(keyNode, innerNode));

--- a/src/test/java/org/raml/validation/ValidationTestCase.java
+++ b/src/test/java/org/raml/validation/ValidationTestCase.java
@@ -212,7 +212,7 @@ public class ValidationTestCase extends AbstractRamlTestCase
         String resource = "org/raml/validation/indentation-broken.raml";
         List<ValidationResult> validationResults = validateRaml(resource);
         assertThat(validationResults.size(), is(1));
-        assertThat(validationResults.get(0).getMessage(), is("expected <block end>, but found BlockMappingStart"));
+        assertThat(validationResults.get(0).getMessage(), is("expected <block end>, but found '<block mapping start>'"));
         assertThat(validationResults.get(0).getLine() + 1, is(12));
     }
 


### PR DESCRIPTION
STUDIO-13040

After the upgrade to raml-parser-2 1.0.38 parsing #%RAML 0.8  fails with
 
java.lang.NoSuchMethodError: org.yaml.snakeyaml.nodes.SequenceNode.getFlowStyle()Ljava/lang/Boolean;
 
This is due in raml-parser-2 1.0.38 the snakeyaml dependency was updated to 1.23, but raml-parser-1  (0.8.31) is still using snakeyaml 1.15. 
 
The issue is in how studio resolves dependencies (pomDependencies.xml) as jars from apikit and raml-parser, which is limited to have only one version of a transitive dependency in the same plugin. So, only snakeyaml 1.23 is used and raml-parser-1 can't work with it.

The proposal is to update to 1.23 in raml-parser-1 also which seems to work just fine.