### PR TITLE
Return to URI slash instead of OS file separator

### DIFF
--- a/src/main/java/org/raml/parser/tagresolver/ContextPath.java
+++ b/src/main/java/org/raml/parser/tagresolver/ContextPath.java
@@ -17,7 +17,6 @@ package org.raml.parser.tagresolver;
 
 import static org.raml.parser.tagresolver.IncludeResolver.INCLUDE_APPLIED_TAG;
 
-import java.io.File;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
@@ -104,7 +103,7 @@ public class ContextPath
 
     public static String getParentPath(String path)
     {
-        int idx = path.lastIndexOf(File.separatorChar) + 1;
+        int idx = path.lastIndexOf("/") + 1;
         return path.substring(0, idx);
     }
 


### PR DESCRIPTION
We need to rollback (#666) to URI format slash, that change broke raml 08 parsing on Windows as it uses backslash. In RAML, paths are unix-like (forward slash). APIKIT needed that change to resolve includes inside XSD files in which other XSD files can be included in a file path way (not URI). However, that change didn’t resolve their issue completely, it is still failing.