### PR TITLE
Adding a way to disable anchor definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ In order to provide more flexibility, users can set different system properties 
 Argument | Description | Default Value
 -------- | ----------- | -------------
 ```yagi.json_duplicate_keys_detection``` | Setting it to true will make the parser fail if any JSON example contains duplicated keys | ```true```
+```yagi.disable_anchors``` | Setting it to true will make the parser fail if any JSON example contains an anchor definition | ```false```
 ```raml.json_schema.fail_on_warning``` | Setting it to true will make the parser fail if any example validated against a particular Json Schema throws a warning message | ```false```
 
 ## Usage

--- a/raml-parser-2/src/test/java/org/raml/v2/api/DisablesAnchorsTestCase.java
+++ b/raml-parser-2/src/test/java/org/raml/v2/api/DisablesAnchorsTestCase.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2013 (c) MuleSoft, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.raml.v2.api;
+
+import static java.lang.Boolean.TRUE;
+import static java.lang.System.clearProperty;
+import static java.lang.System.setProperty;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.raml.yagi.framework.nodes.snakeyaml.NodeParser.DISABLE_ANCHORS_PROPERTY;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+import org.raml.v2.internal.impl.RamlBuilder;
+import org.raml.yagi.framework.nodes.ErrorNode;
+import org.raml.yagi.framework.nodes.Node;
+import org.raml.yagi.framework.nodes.NodeType;
+import org.raml.yagi.framework.nodes.snakeyaml.NodeParser;
+
+/**
+ * Tests {@link NodeParser} behavior about disabling/enabling anchors definitions.
+ */
+public class DisablesAnchorsTestCase
+{
+
+    private static final String RAML_WITH_ANCHOR = ""
+                                                   + "#%RAML 1.0\n"
+                                                   + "title: xml body\n"
+                                                   + "/top:\n"
+                                                   + "    get:\n"
+                                                   + "        body: &bodyPost\n"
+                                                   + "            application/xml:\n"
+                                                   + "                type: User\n"
+                                                   + "        responses:\n"
+                                                   + "            200:\n"
+                                                   + "                body: *bodyPost";
+
+    @Test
+    public void disablesAnchors() throws Exception
+    {
+        final String originalDisabledValue = System.getProperty(DISABLE_ANCHORS_PROPERTY);
+
+        try
+        {
+            setDisabledAnchors(TRUE.toString());
+
+            final RamlBuilder builder = new RamlBuilder();
+
+            final Node raml = builder.build(RAML_WITH_ANCHOR);
+
+            assertThat(raml, notNullValue());
+            assertThat(raml.getType(), equalTo(NodeType.Error));
+            assertThat(((ErrorNode) raml).getErrorMessage(), containsString(
+                    "Underlying error while parsing YAML syntax: 'Attempt to define anchor 'bodyPost' but anchors are disabled."));
+        }
+        finally
+        {
+            setDisabledAnchors(originalDisabledValue);
+        }
+    }
+
+    @Test
+    public void enablesAnchorsByDefault()
+    {
+        final RamlBuilder builder = new RamlBuilder();
+
+        final Node raml = builder.build(RAML_WITH_ANCHOR);
+
+        assertThat(raml, notNullValue());
+        assertThat(raml.getType(), equalTo(NodeType.Object));
+    }
+
+    private void setDisabledAnchors(String newValue)
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException
+    {
+        if (newValue == null)
+        {
+            clearProperty(DISABLE_ANCHORS_PROPERTY);
+        }
+        else
+        {
+            setProperty(DISABLE_ANCHORS_PROPERTY, newValue);
+        }
+        Method setAnchorsDisabledMethod = NodeParser.class.getDeclaredMethod("setAnchorsDisabled");
+        setAnchorsDisabledMethod.setAccessible(true);
+        setAnchorsDisabledMethod.invoke(NodeParser.class);
+    }
+}

--- a/yagi/src/main/java/org/raml/yagi/framework/nodes/snakeyaml/NodeParser.java
+++ b/yagi/src/main/java/org/raml/yagi/framework/nodes/snakeyaml/NodeParser.java
@@ -15,26 +15,54 @@
  */
 package org.raml.yagi.framework.nodes.snakeyaml;
 
+import static org.apache.commons.io.IOUtils.LINE_SEPARATOR_UNIX;
+import static org.apache.commons.io.IOUtils.LINE_SEPARATOR_WINDOWS;
+import static org.apache.commons.lang.SystemUtils.IS_OS_WINDOWS;
+
+import java.io.Reader;
+import java.io.StringReader;
+
+import javax.annotation.Nullable;
+
 import org.raml.v2.api.loader.DefaultResourceLoader;
 import org.raml.v2.api.loader.ResourceLoader;
 import org.raml.yagi.framework.nodes.DefaultPosition;
 import org.raml.yagi.framework.nodes.ErrorNode;
 import org.raml.yagi.framework.nodes.Node;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.composer.Composer;
+import org.yaml.snakeyaml.composer.ComposerException;
 import org.yaml.snakeyaml.error.Mark;
 import org.yaml.snakeyaml.error.MarkedYAMLException;
+import org.yaml.snakeyaml.parser.Parser;
+import org.yaml.snakeyaml.parser.ParserImpl;
 import org.yaml.snakeyaml.reader.ReaderException;
-
-import javax.annotation.Nullable;
-import java.io.Reader;
-import java.io.StringReader;
-
-import static org.apache.commons.io.IOUtils.LINE_SEPARATOR_UNIX;
-import static org.apache.commons.io.IOUtils.LINE_SEPARATOR_WINDOWS;
-import static org.apache.commons.lang.SystemUtils.IS_OS_WINDOWS;
+import org.yaml.snakeyaml.reader.StreamReader;
+import org.yaml.snakeyaml.resolver.Resolver;
 
 public class NodeParser
 {
+
+    public static final String DISABLE_ANCHORS_PROPERTY = "yagi.disable_anchors";
+
+    // This non final to enable setting the value on tests
+    private static boolean ANCHORS_DISABLED;
+
+    /**
+     * Configures the {@link #ANCHORS_DISABLED} field by reading the {@value #DISABLE_ANCHORS_PROPERTY} system property.
+     * <p>
+     *     This method was defined to enable testing by configuring the system property using reflection
+     * </p>
+     */
+    private static void setAnchorsDisabled()
+    {
+        ANCHORS_DISABLED = Boolean.valueOf(System.getProperty(DISABLE_ANCHORS_PROPERTY, "false"));
+    }
+
+    static
+    {
+        setAnchorsDisabled();
+    }
 
     @Nullable
     public static Node parse(ResourceLoader resourceLoader, String resourcePath, Reader reader)
@@ -44,7 +72,7 @@ public class NodeParser
 
         try
         {
-            Yaml yamlParser = new Yaml();
+            Yaml yamlParser = ANCHORS_DISABLED ? new SecureYaml() : new Yaml();
             org.yaml.snakeyaml.nodes.Node composedNode = yamlParser.compose(smartReader);
             if (composedNode == null)
             {
@@ -63,6 +91,72 @@ public class NodeParser
         {
 
             return buildYamlErrorNode(e, smartReader);
+        }
+    }
+
+    /**
+     * Uses a {@link SecureComposer} to disable parsing of anchors
+     */
+    private static class SecureYaml extends Yaml
+    {
+        @Override
+        public org.yaml.snakeyaml.nodes.Node compose(Reader yaml)
+        {
+            Composer composer = new SecureComposer(new ParserImpl(new StreamReader(yaml)), resolver);
+            return composer.getSingleNode();
+        }
+    }
+
+    /**
+     * Defined only to enable exception creation as {@link ComposerException} constructor has protected access
+     */
+    private static class InvalidComposerException extends ComposerException
+    {
+        protected InvalidComposerException(String context, Mark contextMark, String problem, Mark problemMark)
+        {
+            super(context, contextMark, problem, problemMark);
+        }
+    }
+
+    /**
+     * Disables the parsing of anchors
+     */
+    private static class SecureComposer extends Composer
+    {
+        public SecureComposer(Parser parser, Resolver resolver)
+        {
+            super(parser, resolver);
+        }
+
+        @Override
+        protected org.yaml.snakeyaml.nodes.Node composeScalarNode(String anchor)
+        {
+            checkAnchorUsage(anchor);
+            return super.composeScalarNode(anchor);
+        }
+
+        @Override
+        protected org.yaml.snakeyaml.nodes.Node composeSequenceNode(String anchor)
+        {
+            checkAnchorUsage(anchor);
+            return super.composeSequenceNode(anchor);
+        }
+
+        @Override
+        protected org.yaml.snakeyaml.nodes.Node composeMappingNode(String anchor)
+        {
+            checkAnchorUsage(anchor);
+            return super.composeMappingNode(anchor);
+        }
+
+        private void checkAnchorUsage(String anchor)
+        {
+            if (anchor != null)
+            {
+                throw new InvalidComposerException(null, null,
+                        "Attempt to define anchor '" + anchor + "' but anchors are disabled.",
+                        parser.getEvent().getStartMark());
+            }
         }
     }
 


### PR DESCRIPTION
_ Adding yagi.disable_anchors property (default false) that when set to true will make the parsing fail in case of detecting any anchor definition