### PR TITLE
Add Automatic-Module-Name for Java Modules

### DIFF
--- a/raml-parser-2/pom.xml
+++ b/raml-parser-2/pom.xml
@@ -30,7 +30,8 @@
                                     <finalName>${project.artifactId}-${project.version}-full</finalName>
                                     <transformers>
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                            <mainClass>org.raml.v2.internal.impl.RamlValidator</mainClass>
+                                          <mainClass>org.raml.v2.internal.impl.RamlValidator</mainClass>
+                                          <Automatic-Module-Name>org.raml.parser</Automatic-Module-Name>
                                         </transformer>
                                     </transformers>
                                 </configuration>
@@ -137,4 +138,19 @@
         </dependency>
     </dependencies>
 
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                  <Automatic-Module-Name>org.raml.parser</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
 </project>


### PR DESCRIPTION
"2" is not a allowed module name and the default way of turning
jar-names into Java modules translated into "raml.parser.2" which is not
a valid module name, thus preventing this library to be used in a Java
module project. This introduced a MANIFEST.MF entry recommended by the
Java system to explicitly name the module (removing "2") and this
entry should have no affect on exiting non-module projects.

The error shown was:
```
[INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ pkgd-repository-api ---
[WARNING] Can't extract module name from raml-parser-2-1.0.48.jar: raml.parser.2: Invalid module name: '2' is not a Java identifier
```